### PR TITLE
fix: Handle v2/my-data API endpoint failure gracefully

### DIFF
--- a/custom_components/sveasolar/__init__.py
+++ b/custom_components/sveasolar/__init__.py
@@ -205,8 +205,14 @@ class SveaSolarDataUpdateCoordinator(DataUpdateCoordinator):
                 my_data = await self._api.async_get_my_data()
                 for location in my_data:
                     self._location_poll[location.id] = location
+            except (AuthenticationError, asyncio.CancelledError):
+                raise
             except Exception as my_data_err:
-                _LOGGER.warning("Could not fetch location data (my-data endpoint may be unavailable): %s", my_data_err)
+                _LOGGER.warning(
+                    "Could not fetch location data (my-data endpoint may be unavailable): %s",
+                    my_data_err,
+                )
+                self._location_poll.clear()
 
             return self._data_update()
         except AuthenticationError as err:

--- a/custom_components/sveasolar/__init__.py
+++ b/custom_components/sveasolar/__init__.py
@@ -201,9 +201,12 @@ class SveaSolarDataUpdateCoordinator(DataUpdateCoordinator):
                 battery = await self._api.async_get_battery(next(iter(self.system_ids[SveaSolarSystemType.BATTERY][0])))
                 self._battery_poll[battery.id] = battery
 
-            my_data = await self._api.async_get_my_data()
-            for location in my_data:
-                self._location_poll[location.id] = location
+            try:
+                my_data = await self._api.async_get_my_data()
+                for location in my_data:
+                    self._location_poll[location.id] = location
+            except Exception as my_data_err:
+                _LOGGER.warning("Could not fetch location data (my-data endpoint may be unavailable): %s", my_data_err)
 
             return self._data_update()
         except AuthenticationError as err:


### PR DESCRIPTION
## Summary

- The Svea Solar API endpoint `v2/my-data` now returns 404, causing the entire integration to fail during setup
- This wraps the `async_get_my_data()` call in a try/except so EV and battery sensors continue to work

Fixes #13

## Changes

**`custom_components/sveasolar/__init__.py`**: Wrap `async_get_my_data()` in `_async_update_data()` with a try/except that logs a warning instead of propagating the error as `UpdateFailed`.

## Result

| Feature | Before | After |
|---------|--------|-------|
| Integration setup | Fails completely | Starts successfully |
| EV sensors | Not created | ✅ Working |
| Battery sensors | Not created | ✅ Working |
| Location sensors | Not created | ⚠️ Show as "unknown" (expected) |

## Test plan

- [x] Install integration with Svea Solar credentials
- [x] Verify integration starts without error
- [x] Verify EV sensors show charging status, battery level, range
- [x] Verify battery sensors work via WebSocket
- [x] Verify warning is logged for the unavailable endpoint
- [x] Verify location sensors show "unknown" (graceful degradation)


🤖 Generated with [Claude Code](https://claude.com/claude-code)